### PR TITLE
Eliminate need for GET_TASKS permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ This plugin is for use with [Cordova](http://incubator.apache.org/cordova/), and
 
 2) Modify your **AndroidManifest.xml** and add the following lines to your manifest tag:
 
-			<uses-permission android:name="android.permission.GET_TASKS" />
 			<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 			<uses-permission android:name="android.permission.GET_ACCOUNTS" />
 			<uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,6 @@
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest">
-			<uses-permission android:name="android.permission.GET_TASKS" />
 			<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 			<uses-permission android:name="android.permission.GET_ACCOUNTS" />
 			<uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -69,14 +69,12 @@ public class GCMIntentService extends GCMBaseIntentService {
 		Bundle extras = intent.getExtras();
 		if (extras != null)
 		{
-			boolean	foreground = this.isInForeground();
+			PushPlugin.sendExtras(extras);
 
-			extras.putBoolean("foreground", foreground);
-
-			if (foreground)
-				PushPlugin.sendExtras(extras);
-			else
+			// Send a notification if there is a message
+			if (extras.getString("message").length() != 0) {
 				createNotification(context, extras);
+			}
 		}
 	}
 
@@ -143,18 +141,6 @@ public class GCMIntentService extends GCMBaseIntentService {
 		return (String)appName;
 	}
 	
-	public boolean isInForeground()
-	{
-		ActivityManager activityManager = (ActivityManager) getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
-		List<RunningTaskInfo> services = activityManager
-				.getRunningTasks(Integer.MAX_VALUE);
-
-		if (services.get(0).topActivity.getPackageName().toString().equalsIgnoreCase(getApplicationContext().getPackageName().toString()))
-			return true;
-
-		return false;
-	}	
-
 	@Override
 	public void onError(Context context, String errorId) {
 		Log.e(TAG, "onError - errorId: " + errorId);


### PR DESCRIPTION
- Don't check if we are in the foreground - that happens anyway in the
  [PushPlugin.sendExtras()](https://github.com/phonegap-build/PushPlugin/blob/master/src/android/com/plugin/gcm/PushPlugin.java#L111) method
- Only display a message if the message has text to be displayed

Fixes #52 and undoes #3

This might not be a perfect fix, but it seems to work for our application. If anyone has any comments on how to improve before it gets merged, I'd love to improve it.
