### PR TITLE
Enable syntax highlighting for code examples in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,72 +215,72 @@ function tokenHandler (result) {
 // iOS
 function onNotificationAPN (event) {
 	if ( event.alert )
-    {
+	{
 		navigator.notification.alert(event.alert);
 	}
 
 	if ( event.sound )
-    {
+	{
 		var snd = new Media(event.sound);
 		snd.play();
 	}
 
 	if ( event.badge )
-    {
+	{
 		pushNotification.setApplicationIconBadgeNumber(successHandler, errorHandler, event.badge);
 	}
 }
 
 // Android
 function onNotificationGCM(e) {
-    $("#app-status-ul").append('<li>EVENT -> RECEIVED:' + e.event + '</li>');
+	$("#app-status-ul").append('<li>EVENT -> RECEIVED:' + e.event + '</li>');
 
-    switch( e.event )
-    {
-    case 'registered':
+	switch( e.event )
+	{
+	case 'registered':
 		if ( e.regid.length > 0 )
-        {
+		{
 			$("#app-status-ul").append('<li>REGISTERED -> REGID:' + e.regid + "</li>");
 			// Your GCM push server needs to know the regID before it can push to this device
 			// here is where you might want to send it the regID for later use.
 			console.log("regID = " + e.regID);
 		}
-    break;
+	break;
 
-    case 'message':
-    	// if this flag is set, this notification happened while we were in the foreground.
-    	// you might want to play a sound to get the user's attention, throw up a dialog, etc.
-    	if ( e.foreground )
-        {
+	case 'message':
+		// if this flag is set, this notification happened while we were in the foreground.
+		// you might want to play a sound to get the user's attention, throw up a dialog, etc.
+		if ( e.foreground )
+		{
 			$("#app-status-ul").append('<li>--INLINE NOTIFICATION--' + '</li>');
 
 			// if the notification contains a soundname, play it.
 			var my_media = new Media("/android_asset/www/"+e.soundname);
 			my_media.play();
 		}
-        else
-        {  // otherwise we were launched because the user touched a notification in the notification tray.
+		else
+		{  // otherwise we were launched because the user touched a notification in the notification tray.
 			if ( e.coldstart )
-            {
+			{
 				$("#app-status-ul").append('<li>--COLDSTART NOTIFICATION--' + '</li>');
-            }
-            else
-            {
+			}
+			else
+			{
 				$("#app-status-ul").append('<li>--BACKGROUND NOTIFICATION--' + '</li>');
-            }
+			}
 		}
 
 		$("#app-status-ul").append('<li>MESSAGE -> MSG: ' + e.payload.message + '</li>');
 		$("#app-status-ul").append('<li>MESSAGE -> MSGCNT: ' + e.payload.msgcnt + '</li>');
-    break;
+	break;
 
 	case 'error':
 		$("#app-status-ul").append('<li>ERROR -> MSG:' + e.msg + '</li>');
-    break;
+	break;
 
-    default:
+	default:
 		$("#app-status-ul").append('<li>EVENT -> Unknown, an event was received and we do not know what it is</li>');
-    break;
+	break;
   }
 }
 ```


### PR DESCRIPTION
I'm not sure if this is necessary or not but to make code examples a bit easier to read, I enable syntax highlighting for each code block using [Github Flavored Markdown syntax](https://help.github.com/articles/github-flavored-markdown#syntax-highlighting) without changing any content of the code.

Anyway, I followed along the code examples and found some issues (I'm using Cordova 3.0):
- `e` object in `onNotificationGCM()` is changed. `regID` is now `regid` and there are no longer `e.foreground` or `e.coldstart` available.
