### PR TITLE
Added getString method to setContentTitle and setTicker

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -92,8 +92,8 @@ public class GCMIntentService extends GCMBaseIntentService {
 				.setDefaults(Notification.DEFAULT_ALL)
 				.setSmallIcon(context.getApplicationInfo().icon)
 				.setWhen(System.currentTimeMillis())
-				.setContentTitle(appName)
-				.setTicker(appName)
+				.setContentTitle(getString("title"))
+				.setTicker(getString("title"))
 				.setContentIntent(contentIntent);
 
 		String message = extras.getString("message");


### PR DESCRIPTION
What's changed:
ContentTitle and Ticker can now be set from the GCM server via the "title" field in the "data" parameter (appName is no longer hard coded).

I am not really sure why appName was hard coded into these parameters, as most examples for this plug in allows you to set a title. For example, from this tutorial:
http://devgirl.org/2013/07/17/tutorial-implement-push-notifications-in-your-phonegap-application/

The node.js server example is as follows:
**message.addData('title','Push Notification Sample' );**

But the title will not be set and displayed on the device as appName is the hard coded value in _GCMIntentService_
