### PR TITLE
Android : getString should be extras.getString

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -92,8 +92,8 @@ public class GCMIntentService extends GCMBaseIntentService {
 				.setDefaults(Notification.DEFAULT_ALL)
 				.setSmallIcon(context.getApplicationInfo().icon)
 				.setWhen(System.currentTimeMillis())
-				.setContentTitle(getString("title"))
-				.setTicker(getString("title"))
+				.setContentTitle(extras.getString("title"))
+				.setTicker(extras.getString("title"))
 				.setContentIntent(contentIntent);
 
 		String message = extras.getString("message");


### PR DESCRIPTION
Plugin was failing to build : 

[javac] Compiling 8 source files to (...)/platforms/android/bin/classes
[javac](...)/platforms/android/src/com/plugin/gcm/GCMIntentService.java:96: cannot find symbol
[javac] symbol  : method getString(java.lang.String)
[javac] location: class com.plugin.gcm.GCMIntentService
[javac]                 .setTicker(getString("title"))
