### PR TITLE
JSON fix

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -164,11 +164,11 @@
 
         if (isInline)
         {
-            [jsonStr appendFormat:@"foreground:'%d',", 1];
+            [jsonStr appendFormat:@"foreground:\"%d\"", 1];
             isInline = NO;
         }
 		else
-            [jsonStr appendFormat:@"foreground:'%d',", 0];
+            [jsonStr appendFormat:@"foreground:\"%d\"", 0];
         
         [jsonStr appendString:@"}"];
 


### PR DESCRIPTION
I was having issues sending push notifications that included a single quote in them. The plugin incorrectly converts the NSDictionary to JSON with single quotes which is not conferment to the spec: http://www.json.org/

Also removed an invalid trailing comma
