### PR TITLE
#85 No notifications in android when the app is closed

### DIFF
--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -234,6 +234,7 @@ public class PushPlugin extends CordovaPlugin {
 		GCMRegistrar.onDestroy(getApplicationContext());
 		gWebView = null;
 		gECB = null;
+		gForeground = false;
 		super.onDestroy();
 	}
 }


### PR DESCRIPTION
Allow the plugin to know when the app is no longer in foreground so that it may receive push notifications
