### PR TITLE
Issue 94 - Attempt to fix for double notification handler being called

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -67,12 +67,14 @@ public class GCMIntentService extends GCMBaseIntentService {
 		Bundle extras = intent.getExtras();
 		if (extras != null)
 		{
-			PushPlugin.sendExtras(extras);
 
 			// Send a notification if there is a message
 			if (extras.getString("message").length() != 0) {
 				createNotification(context, extras);
 			}
+            else {
+                PushPlugin.sendExtras(extras);
+            }
 		}
 	}
 


### PR DESCRIPTION
Issue 94 - Attempt to fix for double notification handler being called when PN arrives and app is inactive (but not closed).
