### PR TITLE
json key should be surrounded by quotation

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -194,7 +194,12 @@
         if ([thisObject isKindOfClass:[NSDictionary class]])
             [self parseDictionary:thisObject intoJSON:jsonString];
         else
-            [jsonString appendFormat:@"\"%@\":\"%@\",", key, [inDictionary objectForKey:key]];
+            [jsonString appendFormat:@"\"%@\":\"%@\",",
+             key,
+             [[[[inDictionary objectForKey:key]
+               stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"]
+                stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""]
+                stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"]];
     }
 }
 


### PR DESCRIPTION
JSON's key may includes dot or blank which cannot be converted into string. In that case 'Unpexpected token' syntax error will cause. So key should be double-quoted.
