### PR TITLE
fix e.regid in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ function onNotificationGCM(e) {
 			$("#app-status-ul").append('<li>REGISTERED -> REGID:' + e.regid + "</li>");
 			// Your GCM push server needs to know the regID before it can push to this device
 			// here is where you might want to send it the regID for later use.
-			console.log("regID = " + e.regID);
+			console.log("regID = " + e.regid);
 		}
 	break;
 


### PR DESCRIPTION
GCM push server send 'regid', not regID.
