### PR TITLE
All (targetting Android): Add a new setup method to initialize the Android version without contacting the GCM.

### DIFF
--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -24,6 +24,7 @@ import com.google.android.gcm.*;
 public class PushPlugin extends CordovaPlugin {
 	public static final String TAG = "PushPlugin";
 	
+	public static final String SETUP = "setup";
 	public static final String REGISTER = "register";
 	public static final String UNREGISTER = "unregister";
 	public static final String EXIT = "exit";
@@ -49,7 +50,7 @@ public class PushPlugin extends CordovaPlugin {
 
 		Log.v(TAG, "execute: action=" + action);
 
-		if (REGISTER.equals(action)) {
+		if (REGISTER.equals(action) || SETUP.equals(action)) {
 
 			Log.v(TAG, "execute: data=" + data.toString());
 
@@ -64,7 +65,10 @@ public class PushPlugin extends CordovaPlugin {
 
 				Log.v(TAG, "execute: ECB=" + gECB + " senderID=" + gSenderID);
 
-				GCMRegistrar.register(getApplicationContext(), gSenderID);
+				if (REGISTER.equals(action)) {
+					// Do not register with GCM during SETUP (can work offline, faster)
+					GCMRegistrar.register(getApplicationContext(), gSenderID);
+				}
 				result = true;
 				callbackContext.success();
 			} catch (JSONException e) {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -43,6 +43,11 @@
     [self successWithMessage:@"unregistered"];
 }
 
+- (void)setup:(CDVInvokedUrlCommand*)command;
+{
+    // This is a no-op for iOS, added for symetry with the Android version
+}
+
 - (void)register:(CDVInvokedUrlCommand*)command;
 {
 	self.callbackId = command.callbackId;

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -1,7 +1,6 @@
 var PushNotification = function() {
 };
 
-
 // Call this to register for push notifications. Content of [options] depends on whether we are working with APNS (iOS) or GCM (Android)
 PushNotification.prototype.register = function(successCallback, errorCallback, options) {
     if (errorCallback == null) { errorCallback = function() {}}
@@ -18,6 +17,26 @@ PushNotification.prototype.register = function(successCallback, errorCallback, o
 
 	cordova.exec(successCallback, errorCallback, "PushPlugin", "register", [options]);
 };
+
+// Call this to setup the plugin without registering with APNS or GCM.
+// The [options] are the same as for the register function.
+// This is useful for faster plugin startup on Android but not required if already using register
+PushNotification.prototype.setup = function(successCallback, errorCallback, options) {
+    if (errorCallback == null) { errorCallback = function() {}}
+
+    if (typeof errorCallback != "function")  {
+        console.log("PushNotification.setup failure: failure parameter not a function");
+        return
+    }
+
+    if (typeof successCallback != "function") {
+        console.log("PushNotification.setup failure: success callback parameter must be a function");
+        return
+    }
+
+    cordova.exec(successCallback, errorCallback, "PushPlugin", "setup", [options]);
+};
+
 
 // Call this to unregister for push notifications
 PushNotification.prototype.unregister = function(successCallback, errorCallback) {


### PR DESCRIPTION
Also, add the method to iOS for symmetry, although it is a no-op there.

This new setup method is specially useful on coldstart or background situations,
since the notification can be processed even if the network is unreachable.

Background:

In our use case (I think it is quite general), calling GCM also requires us to provide the tokens to the server so it can deliver the notifications later on. This network use is most often not required (and potentially slow, depending on signal quality), since the tokens will remain valid, so we decided to not "register" every time the app is started. 

On Android, skipping the call to register stops the notifications from being processed since the reference to the WebView and ECB are not configured.
