### PR TITLE
Mark PushHandlerActivity as exported (avoids security exception)

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>PushPlugin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<activity android:name="com.plugin.gcm.PushHandlerActivity"/>
+			<activity android:name="com.plugin.gcm.PushHandlerActivity" android:exported="true"/>
 			<receiver android:name="com.plugin.gcm.CordovaGCMBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >
 				<intent-filter>
 					<action android:name="com.google.android.c2dm.intent.RECEIVE" />


### PR DESCRIPTION
Mark PushHandlerActivity as exported (avoids security exception on Intent dispatch at runtime). Tested on Android 4.4, LG Nexus 4
