### PR TITLE
Typo Fixin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ where
 Alternatively this plugin can be installed using the Phonegap CLI.
 
 1) Navigate to the root folder for your phonegap project.
+
 2) Run the command.
 
 ```sh


### PR DESCRIPTION
In the README:
 changed 'Navigaate' to 'Navigate',
 added a new line to differentiate ordered list
