### PR TITLE
Allow unique notification icons for separate notifications

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -25,7 +25,7 @@ import com.google.android.gcm.GCMBaseIntentService;
 
 @SuppressLint("NewApi")
 public class GCMIntentService extends GCMBaseIntentService {
-
+	
 	public static final int NOTIFICATION_ID = 237;
 	private static final String TAG = "GCMIntentService";
 	
@@ -72,24 +72,28 @@ public class GCMIntentService extends GCMBaseIntentService {
 		Bundle extras = intent.getExtras();
 		if (extras != null)
 		{
-			
+
 			String cancelNotificationString = extras.getString("cancelNotification");
 
 			if (cancelNotificationString != null) 
 		{
-			
+
+			Integer CurrentNotificationID=null;
 			String notIdOnMessage = extras.getString("notId");
 				if (notIdOnMessage != null) {
-				NOTIFICATION_ID = Integer.parseInt(extras.getString("notId"));
+					CurrentNotificationID = Integer.parseInt(extras.getString("notId"));
 				}
-			
+				else {
+					CurrentNotificationID=NOTIFICATION_ID;
+				}
+
 			NotificationManager mNotificationManagerCancel = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-			mNotificationManagerCancel.cancel((String)getAppName(context), NOTIFICATION_ID);	
+			mNotificationManagerCancel.cancel((String)getAppName(context), CurrentNotificationID);	
 		}
-			
+
 			else
 			{
-			
+
 			// if we are in the foreground, just surface the payload, else post it to the statusbar
             if (PushPlugin.isInForeground()) {
 				extras.putBoolean("foreground", true);
@@ -106,7 +110,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 			}
             }
         }
-}
+	}
 
 	public void createNotification(Context context, Bundle extras)
 	{
@@ -118,6 +122,8 @@ public class GCMIntentService extends GCMBaseIntentService {
 		notificationIntent.putExtra("pushBundle", extras);
 
 		PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+		
+		
 		
 		
 		Bitmap myBitmap = null;
@@ -161,6 +167,15 @@ public class GCMIntentService extends GCMBaseIntentService {
 			mBuilder.setNumber(Integer.parseInt(msgcnt));
 		}
 		
+		String messageBig = extras.getString("messageBig");
+		if (msgcnt != null) {
+			mBuilder.setStyle(new NotificationCompat.BigTextStyle()
+			 .bigText(messageBig));
+		}
+		
+		
+       
+		
 		int notId = 0;
 		
 		try {
@@ -173,9 +188,20 @@ public class GCMIntentService extends GCMBaseIntentService {
 			Log.e(TAG, "Number format exception - Error parsing Notification ID" + e.getMessage());
 		}
 		
-		mNotificationManager.notify((String) appName, notId, mBuilder.build());
+		
+		Notification notification = mBuilder.build();
+		notification.defaults |= Notification.DEFAULT_VIBRATE;
+        notification.defaults |= Notification.DEFAULT_SOUND;
+        
+        notification.tickerText = extras.getString("title") + "\n" + messageBig;
+		
+		
+		mNotificationManager.notify((String) appName, notId, notification);
 		
 	}
+	
+	
+	
 	
 	private static String getAppName(Context context)
 	{

--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -26,6 +26,7 @@ import com.google.android.gcm.GCMBaseIntentService;
 @SuppressLint("NewApi")
 public class GCMIntentService extends GCMBaseIntentService {
 
+	public static final int NOTIFICATION_ID = 237;
 	private static final String TAG = "GCMIntentService";
 	
 	public GCMIntentService() {
@@ -71,6 +72,24 @@ public class GCMIntentService extends GCMBaseIntentService {
 		Bundle extras = intent.getExtras();
 		if (extras != null)
 		{
+			
+			String cancelNotificationString = extras.getString("cancelNotification");
+
+			if (cancelNotificationString != null) 
+		{
+			
+			String notIdOnMessage = extras.getString("notId");
+				if (notIdOnMessage != null) {
+				NOTIFICATION_ID = Integer.parseInt(extras.getString("notId"));
+				}
+			
+			NotificationManager mNotificationManagerCancel = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+			mNotificationManagerCancel.cancel((String)getAppName(context), NOTIFICATION_ID);	
+		}
+			
+			else
+			{
+			
 			// if we are in the foreground, just surface the payload, else post it to the statusbar
             if (PushPlugin.isInForeground()) {
 				extras.putBoolean("foreground", true);
@@ -83,9 +102,11 @@ public class GCMIntentService extends GCMBaseIntentService {
                 if (extras.getString("message") != null && extras.getString("message").length() != 0) {
                     createNotification(context, extras);
                 }
+                
+			}
             }
         }
-	}
+}
 
 	public void createNotification(Context context, Bundle extras)
 	{

--- a/src/android/com/plugin/gcm/PushHandlerActivity.java
+++ b/src/android/com/plugin/gcm/PushHandlerActivity.java
@@ -25,8 +25,6 @@ public class PushHandlerActivity extends Activity
 		boolean isPushPluginActive = PushPlugin.isActive();
 		processPushBundle(isPushPluginActive);
 
-		GCMIntentService.cancelNotification(this);
-
 		finish();
 
 		if (!isPushPluginActive) {


### PR DESCRIPTION
Modeled after Facebook / Google Hangouts ability for each notification to have a different icon depending on the message (i.e. if you get a message from Jan, Jan's picture shows up as the notification icon, if you get a message from Bill, Bill's picture shows up as the notification icon, etc.).

Just pass the url of the image you want to show up for that particular notification as the variable "icon" in your GCM request. Works like this in the GCM request:
(modeled after http://stackoverflow.com/questions/11242743/gcm-with-php-google-cloud-messaging)

<?php
// Replace with real BROWSER API key from Google APIs
$apiKey = "asAdds235fsdfsdf2342aEl3432534634BNgg";

// Replace with real client registration IDs. Put the correct registration id you are getting from app. If you are using eclipse check your logcat you will get it there.
$registrationIDs = array( "APA91bHpXL6QHMUMVjR1WB3sNTwCEj243434342525345LXAR2Mwp6KJKmTTp9hqE-b57683424233YjMJH5vZIEtbNbyUWOVQhS5gFEjJQLYs5pvEdqpPkHn9VeFp1A" );

/\* Message to be sent - Make sure that message is the key you are using in GCMIntentService.java onMessage() ->  extras.getString("message"); */

$message = "Life is incredibly exciting ....";
$title="You have a message.";

// Set POST variables.
$url = 'https://android.googleapis.com/gcm/send';
$icon='http://www.example.com/BillsProfilePicture.jpg';

$fields = array(
  'registration_ids'  => $registrationIDs,
  'data'              => array( "message" => $message, "title" => $title, "notId"=>'300', "icon"=>$icon ) 
);

$headers = array( 
     'Authorization: key=' . $apiKey,
     'Content-Type: application/json'
);

// Open connection
$ch = curl_init();

// Set the url, number of POST vars, POST data
curl_setopt( $ch, CURLOPT_URL, $url );

curl_setopt( $ch, CURLOPT_POST, true );
curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers);
curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0); 
curl_setopt( $ch, CURLOPT_POSTFIELDS, json_encode( $fields ) );

// Execute post
$result = curl_exec($ch);

// Close connection
curl_close($ch);

// Echo success or failure
echo $result;

?>

---

Also, FYI, I merged the code from TheNewMR from here to allow for stacked notifications depending on different notification ID's:
https://github.com/thenewmr/PushPlugin/commit/728e975442e45668b7d809aec028396a9b023dfa

Instructions for how that works are on that page, however in case it gets deleted for some reason I'll copy/paste here: 

"This allows for multiple notifications to be displayed on Android.  Simply add data with key "notId" and an integer value when sending via GCM.  Differentiate between different notifications by setting different notIds.  Defaults to 0 if not key supplied."
