### PR TITLE
Fix xml validation for plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
     id="com.phonegap.plugins.PushPlugin"
     version="2.2.0">
 


### PR DESCRIPTION
There was a missing import for <amazon:> tag that landing in error in validation, fixed by adding the import of xmlns.
