### PR TITLE
getThreadPool instead of getActivity

### DIFF
--- a/src/android/com/plugin/gcm/PushPlugin.java
+++ b/src/android/com/plugin/gcm/PushPlugin.java
@@ -39,7 +39,7 @@ public class PushPlugin extends CordovaPlugin {
 	 * @return the application context
 	 */
 	private Context getApplicationContext() {
-		return this.cordova.getActivity().getApplicationContext();
+		return this.cordova.getThreadPool().getApplicationContext();
 	}
 
 	@Override


### PR DESCRIPTION
Fix this error:

W/PluginManager(  502): THREAD WARNING: exec() call to PushPlugin.register blocked the main thread for 27ms. Plugin should use CordovaInterface.getThreadPool().
