### PR TITLE
Reference dependencies in example

### DIFF
--- a/Example/www/index.html
+++ b/Example/www/index.html
@@ -66,10 +66,12 @@ NOTE:
             function onNotificationAPN(e) {
                 if (e.alert) {
                      $("#app-status-ul").append('<li>push-notification: ' + e.alert + '</li>');
+                     // showing an alert also requires the org.apache.cordova.dialogs plugin
                      navigator.notification.alert(e.alert);
                 }
                     
                 if (e.sound) {
+                    // playing a sound also requires the org.apache.cordova.media plugin
                     var snd = new Media(e.sound);
                     snd.play();
                 }
@@ -106,6 +108,7 @@ NOTE:
 					                // On Amazon FireOS all custom attributes are contained within payload
 					                var soundfile = e.soundname || e.payload.sound;
 					                // if the notification contains a soundname, play it.
+					                // playing a sound also requires the org.apache.cordova.media plugin
 					                var my_media = new Media("/android_asset/www/"+ soundfile);
 
 							my_media.play();


### PR DESCRIPTION
The example code makes use of some implicit dependencies like the `dialogs` and `media` plugins.

This adds a comment to the lines referencing those plugins, explaining that dependency. That should help prevent issues like #243.
