### PR TITLE
Prevent an iOS crash from didRegisterForRemoteNotificationsWithDeviceToken

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -143,8 +143,6 @@
         [results setValue:dev.name forKey:@"deviceName"];
         [results setValue:dev.model forKey:@"deviceModel"];
         [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
-
-		[self successWithMessage:[NSString stringWithFormat:@"%@", token]];
     #endif
 }
 


### PR DESCRIPTION
didRegisterForRemoteNotificationsWithDeviceToken is being called from AppDelegate but send Plugin success result before plugin being init. As a result callbackId is nil and crash CDVPlugin on iOS.
