### PR TITLE
backwards compatability for ios7 and ios8

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -85,7 +85,12 @@
 
     isInline = NO;
 
-    [[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:(UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeBadge) categories:nil]];
+        [[UIApplication sharedApplication] registerForRemoteNotifications]; // you can also set here for local notification.
+    #else
+        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
+    #endif
 	
 	if (notificationMessage)			// if there is a pending startup notification
 		[self notificationReceived];	// go ahead and process it


### PR DESCRIPTION
Small edit to PushPlugin.m to work with iOS8's new code for registering for remote notifications. Added in conditional code to tell the compiler which piece of code to use for iOS7 and iOS8 so that it is backwards compatible, tested on iOS8 and iOS7 successfully.
