### PR TITLE
Show notification in notification tray always

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -63,18 +63,17 @@ public class GCMIntentService extends GCMBaseIntentService {
 		Bundle extras = intent.getExtras();
 		if (extras != null)
 		{
-			// if we are in the foreground, just surface the payload, else post it to the statusbar
+			// if we are in the foreground, surface the payload
             if (PushPlugin.isInForeground()) {
 				extras.putBoolean("foreground", true);
                 PushPlugin.sendExtras(extras);
 			}
 			else {
 				extras.putBoolean("foreground", false);
-
-                // Send a notification if there is a message
-                if (extras.getString("message") != null && extras.getString("message").length() != 0) {
-                    createNotification(context, extras);
-                }
+            }
+            // Send a notification if there is a message
+            if (extras.getString("message") != null && extras.getString("message").length() != 0) {
+                createNotification(context, extras);
             }
         }
 	}


### PR DESCRIPTION
Unlike iOS, applications on Android show notifications in the notification tray even when received while the application is in the foreground.
