### PR TITLE
fix failure to handle arrays in iOS and other improvements based on NSJSONSerialization

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -154,55 +154,36 @@
 }
 
 - (void)notificationReceived {
-    NSLog(@"Notification received");
-
+    NSLog(@"PushPlugin_NOTIFICATION_RECEIVED");
+    //NSLog(@"PushPlugin_NOTIFICATION: %@", notificationMessage);
     if (notificationMessage && self.callback)
     {
-        NSMutableString *jsonStr = [NSMutableString stringWithString:@"{"];
+        NSMutableDictionary *editableNotification = [notificationMessage mutableCopy];
+        NSError *error;
 
-        [self parseDictionary:notificationMessage intoJSON:jsonStr];
-
-        if (isInline)
-        {
-            [jsonStr appendFormat:@"foreground:\"%d\"", 1];
+        if (isInline) {
+            [editableNotification setObject:@1 forKey:@"foreground"];
             isInline = NO;
         }
-		else
-            [jsonStr appendFormat:@"foreground:\"%d\"", 0];
-        
-        [jsonStr appendString:@"}"];
-
-        NSLog(@"Msg: %@", jsonStr);
-
-        NSString * jsCallBack = [NSString stringWithFormat:@"%@(%@);", self.callback, jsonStr];
-        [self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
-        
-        self.notificationMessage = nil;
-    }
-}
-
-// reentrant method to drill down and surface all sub-dictionaries' key/value pairs into the top level json
--(void)parseDictionary:(NSDictionary *)inDictionary intoJSON:(NSMutableString *)jsonString
-{
-    NSArray         *keys = [inDictionary allKeys];
-    NSString        *key;
-    
-    for (key in keys)
-    {
-        id thisObject = [inDictionary objectForKey:key];
-    
-        if ([thisObject isKindOfClass:[NSDictionary class]])
-            [self parseDictionary:thisObject intoJSON:jsonString];
-        else if ([thisObject isKindOfClass:[NSString class]])
-             [jsonString appendFormat:@"\"%@\":\"%@\",",
-              key,
-              [[[[inDictionary objectForKey:key]
-                stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"]
-                 stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""]
-                 stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"]];
         else {
-            [jsonString appendFormat:@"\"%@\":\"%@\",", key, [inDictionary objectForKey:key]];
+            [editableNotification setObject:@0 forKey:@"foreground"];
         }
+
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:editableNotification
+                                                           options:0
+                                                             error:&error];
+        if (! jsonData) {
+            NSLog(@"PushPlugin_ERROR: %@", error);
+        } else {
+            NSString *jsonStr = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+
+            NSLog(@"PushPlugin_JSON: %@",jsonStr);
+
+            NSString * jsCallBack = [NSString stringWithFormat:@"%@(%@);", self.callback, jsonStr];
+            [self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
+        }
+
+        self.notificationMessage = nil;
     }
 }
 


### PR DESCRIPTION
This fix was created using the code @mrsubtle posted in #221.

More discussion can be found on that issue, but the gist of it is:
- No longer fails on arrays
- Uses NSJSONSerialization to correctly encode the notification as JSON
- breaking change: Number and Boolean types will now come through as Numbers and Booleans rather than Strings -- they are not quoted in the json
- breaking change: 'foreground' parameter, added by the plugin, is also a Number now

The breaks seem worth it to me so that we can have correct encoding of types in the notifications.

I also would be in favor of passing a second argument to onNotificationAPN, `{foreground: <Boolean>}`, instead of sticking it unexpectedly into the _otherwise_ user specified notification body.  Happy to make another pull request for that change if others want it.
