### PR TITLE
Support for custom sounds on Android

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -9,6 +9,8 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -118,6 +120,14 @@ public class GCMIntentService extends GCMBaseIntentService {
 		String msgcnt = extras.getString("msgcnt");
 		if (msgcnt != null) {
 			mBuilder.setNumber(Integer.parseInt(msgcnt));
+		}
+		
+		String soundName = extras.getString("sound");
+		if (soundName != null) {
+			Resources r = getResources();
+			int resourceId = r.getIdentifier(soundName, "raw", context.getPackageName());
+			Uri soundUri = Uri.parse("android.resource://" + context.getPackageName() + "/" + resourceId);
+			mBuilder.setSound(soundUri);
 		}
 		
 		int notId = 0;


### PR DESCRIPTION
To make use of this, the sound must be placed in the platforms/android/res/raw folder and must be of one of the supported media types (http://developer.android.com/guide/appendix/media-formats.html).

In the push notification payload, specify the sound without the file extension. If your file is named "platforms/android/res/raw/alert.mp3", use "alert" as the name.
