### PR TITLE
FIX iOS register for iOS version < 8

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -125,6 +125,8 @@
     UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UserNotificationTypes categories:nil];
     [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
     [[UIApplication sharedApplication] registerForRemoteNotifications];
+#else
+    [[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
 #endif
     
     self.callback = [options objectForKey:@"ecb"];


### PR DESCRIPTION
In iOS < 8 the register function never executes `registerForRemoteNotificationTypes`
