### PR TITLE
Change payload message as alert.

### DIFF
--- a/Example/server/pushGCM.rb
+++ b/Example/server/pushGCM.rb
@@ -4,6 +4,6 @@ GCM.host = 'https://android.googleapis.com/gcm/send'
 GCM.format = :json
 GCM.key = "API_KEY_GOES_HERE"
 destination = ["REGISTRATION_ID_GOES_HERE"]
-data = {:message => "PhoneGap Build rocks!", :msgcnt => "1", :soundname => "beep.wav"}
+data = {:alert => "PhoneGap Build rocks!", :msgcnt => "1", :soundname => "beep.wav"}
 
 GCM.send_notification( destination, data)

--- a/Example/www/index.html
+++ b/Example/www/index.html
@@ -121,7 +121,7 @@ NOTE:
 							$("#app-status-ul").append('<li>--BACKGROUND NOTIFICATION--' + '</li>');
 						}
 							
-						$("#app-status-ul").append('<li>MESSAGE -> MSG: ' + e.payload.message + '</li>');
+						$("#app-status-ul").append('<li>MESSAGE -> MSG: ' + e.payload.alert + '</li>');
                         //android only
 						$("#app-status-ul").append('<li>MESSAGE -> MSGCNT: ' + e.payload.msgcnt + '</li>');
                         //amazon-fireos only

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Cordova Push Notifications Plugin for Android, iOS, WP8, Windows8, BlackBerry 10 and Amazon Fire OS
+# [DEPRECATED] Cordova Push Notifications Plugin for Android, iOS, WP8, Windows8, BlackBerry 10 and Amazon Fire OS
+
+
+### _This plugin is deprecated, i.e. it is no longer maintained. Going forward additional features and bug fixes will be added to the new [phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push) repository._
+
 
 ## DESCRIPTION
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="com.phonegap.plugins.PushPlugin"
-    version="2.4.0">
+    version="2.5.0">
 
   <name>PushPlugin</name>
 	<author>Bob Easterday</author>

--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -72,7 +72,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 				extras.putBoolean("foreground", false);
 
                 // Send a notification if there is a message
-                if (extras.getString("message") != null && extras.getString("message").length() != 0) {
+                if (extras.getString("alert") != null && extras.getString("alert").length() != 0) {
                     createNotification(context, extras);
                 }
             }
@@ -108,11 +108,11 @@ public class GCMIntentService extends GCMBaseIntentService {
 				.setContentIntent(contentIntent)
 				.setAutoCancel(true);
 
-		String message = extras.getString("message");
-		if (message != null) {
-			mBuilder.setContentText(message);
+		String alert = extras.getString("alert");
+		if (alert != null) {
+			mBuilder.setContentText(alert);
 		} else {
-			mBuilder.setContentText("<missing message content>");
+			mBuilder.setContentText("<missing alert content>");
 		}
 
 		String msgcnt = extras.getString("msgcnt");


### PR DESCRIPTION
When building cross platform unify push server backend, usually we would like to standardize backend API into unified format, similar as AeroGear's RESTful API (http://aerogear.org/docs/specs/aerogear-unifiedpush-rest/sender/index.html)

> RESTful API for sending Push Notifications. The Endpoint is protected using HTTP Basic (credentials PushApplicationID:masterSecret).
> 
> Messages are submitted as flexible JSON maps, like:
> 
> curl -3 -u "PushApplicationID:MasterSecret"
>    -v -H "Accept: application/json" -H "Content-type: application/json"
>    -X POST
>    -d '{
>      "alias" : ["someUsername"],
>      "deviceType" : ["someDevice"],
>      "categories" : ["someCategories"],
>      "variants" : ["someVariantIDs"],
>      "ttl" : 3600,
>      "message":
>      {
>        "key":"value",
>        "key2":"other value",
>        "alert":"HELLO!",
>        "action-category":"some value",
>        "sound":"default",
>        "badge":2,
>        "content-available" : true
>      },
>      "simple-push":"version=123"
>    }'
>    https://SERVER:PORT/CONTEXT/rest/sender
> 
> Details about the Message Format can be found HERE! 

Refer to AeroGear's suggestion about unify developer experience (http://aerogear.org/docs/unifiedpush/push-message-format/#cordova-android-special-keys):

> Cordova Android special keys
> To make the user experience the same on iOS and Android, for cordova users, we use the iOS alert ‘key’ on Android as well to generate a notification for you. And we’ve introduced a ‘title’ that can optionally be used for the title of this notification, if none is specified the application name will be used like on iOS.

This patch simply modify the payload's key from hardcoded "message" to "alert", so sharing a similar experience as like as IOS for Android.
