### PR TITLE
Adding missing cordova notifications due to swizzling

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -8,6 +8,8 @@
 
 #import "AppDelegate.h"
 
+extern NSString* const CDVRemoteNotificationReceived;
+
 @interface AppDelegate (notification)
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -10,6 +10,8 @@
 #import "PushPlugin.h"
 #import <objc/runtime.h>
 
+NSString* const CDVRemoteNotificationReceived = @"CDVRemoteNotificationReceived";
+
 static char launchNotificationKey;
 
 @implementation AppDelegate (notification)
@@ -24,7 +26,7 @@ static char launchNotificationKey;
 + (void)load
 {
     Method original, swizzled;
-    
+
     original = class_getInstanceMethod(self, @selector(init));
     swizzled = class_getInstanceMethod(self, @selector(swizzled_init));
     method_exchangeImplementations(original, swizzled);
@@ -34,7 +36,7 @@ static char launchNotificationKey;
 {
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(createNotificationChecker:)
                name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
-	
+
 	// This actually calls the original init method over in AppDelegate. Equivilent to calling super
 	// on an overrided method, this is not recursive, although it appears that way. neat huh?
 	return [self swizzled_init];
@@ -53,24 +55,32 @@ static char launchNotificationKey;
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    // re-post ( broadcast )
+    NSString* token = [[[[deviceToken description]
+                         stringByReplacingOccurrencesOfString: @"<" withString: @""]
+                        stringByReplacingOccurrencesOfString: @">" withString: @""]
+                       stringByReplacingOccurrencesOfString: @" " withString: @""];
+
     PushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];
-    [pushHandler didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    [pushHandler didRegisterForRemoteNotificationsWithDeviceToken:token];
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDVRemoteNotification object:token];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
     PushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];
     [pushHandler didFailToRegisterForRemoteNotificationsWithError:error];
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDVRemoteNotificationError object:error];
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     NSLog(@"didReceiveNotification");
-    
+
     // Get application state for iOS4.x+ devices, otherwise assume active
     UIApplicationState appState = UIApplicationStateActive;
     if ([application respondsToSelector:@selector(applicationState)]) {
         appState = application.applicationState;
     }
-    
+
     if (appState == UIApplicationStateActive) {
         PushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];
         pushHandler.notificationMessage = userInfo;
@@ -80,18 +90,19 @@ static char launchNotificationKey;
         //save it for later
         self.launchNotification = userInfo;
     }
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDVRemoteNotificationReceived object:userInfo];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    
+
     NSLog(@"active");
-    
+
     //zero badge
     application.applicationIconBadgeNumber = 0;
 
     if (self.launchNotification) {
         PushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];
-		
+
         pushHandler.notificationMessage = self.launchNotification;
         self.launchNotification = nil;
         [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -1,16 +1,16 @@
 /*
  Copyright 2009-2011 Urban Airship Inc. All rights reserved.
- 
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
- 
+
  1. Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
- 
+
  2. Redistributions in binaryform must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided withthe distribution.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -33,7 +33,7 @@
     BOOL    isInline;
     NSString *notificationCallbackId;
     NSString *callback;
-    
+
     BOOL ready;
 }
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -81,7 +81,7 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
             UserNotificationTypes |= UIUserNotificationTypeSound;
 #endif
-    }
+        }
     }
     else if ([soundArg boolValue]) {
         notificationTypes |= UIRemoteNotificationTypeSound;
@@ -97,7 +97,7 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
             UserNotificationTypes |= UIUserNotificationTypeAlert;
 #endif
-    }
+        }
     }
     else if ([alertArg boolValue]) {
         notificationTypes |= UIRemoteNotificationTypeAlert;
@@ -124,11 +124,12 @@
         [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
         [[UIApplication sharedApplication] registerForRemoteNotifications];
     } else {
-    		[[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
+    	[[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
     }
 #else
-		[[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
+	[[UIApplication sharedApplication] registerForRemoteNotificationTypes:notificationTypes];
 #endif
+
 
 	if (notificationMessage)			// if there is a pending startup notification
 		[self notificationReceived];	// go ahead and process it
@@ -142,13 +143,10 @@
 }
 */
 
-- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken {
 
     NSMutableDictionary *results = [NSMutableDictionary dictionary];
-    NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
-                        stringByReplacingOccurrencesOfString:@">" withString:@""]
-                       stringByReplacingOccurrencesOfString: @" " withString: @""];
-    [results setValue:token forKey:@"deviceToken"];
+    [results setValue:deviceToken forKey:@"deviceToken"];
 
     #if !TARGET_IPHONE_SIMULATOR
         // Get Bundle Info for Remote Registration (handy if you have more than one app)
@@ -187,7 +185,7 @@
         [results setValue:dev.model forKey:@"deviceModel"];
         [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
 
-		[self successWithMessage:[NSString stringWithFormat:@"%@", token]];
+		[self successWithMessage:[NSString stringWithFormat:@"%@", deviceToken]];
     #endif
 }
 


### PR DESCRIPTION
Due to the swizzle method of gaining control of the AppDelegate this stops other applications from hooking into the NSNotifications which are normally post under the regular AppDelegate on the latest cordova. This PR replicated those notifications when PushPlugin is installed
