### PR TITLE
Fix WP8 first register error

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -105,8 +105,10 @@
         UserNotificationTypes |= UIUserNotificationTypeAlert;
 #endif
     }
-
-    notificationTypes |= UIRemoteNotificationTypeNewsstandContentAvailability;
+	
+	// Commented @see https://github.com/phonegap-build/PushPlugin/issues/365
+    // notificationTypes |= UIRemoteNotificationTypeNewsstandContentAvailability;
+	
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
     UserNotificationTypes |= UIUserNotificationActivationModeBackground;
 #endif

--- a/src/wp8/PushPlugin.cs
+++ b/src/wp8/PushPlugin.cs
@@ -29,7 +29,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             if (pushChannel == null)
             {
                 pushChannel = new HttpNotificationChannel(this.pushOptions.ChannelName);
-
+				SubscribePushChannelEvents(pushChannel);
                 try
                 {
                     pushChannel.Open();
@@ -43,8 +43,10 @@ namespace WPCordovaClassLib.Cordova.Commands
                 pushChannel.BindToShellToast();
                 pushChannel.BindToShellTile();
             }
-
-            SubscribePushChannelEvents(pushChannel);
+			else {
+				SubscribePushChannelEvents(pushChannel);
+			}
+			
             var result = new RegisterResult
             {
                 ChannelName = this.pushOptions.ChannelName,


### PR DESCRIPTION
FIX Problem when first register in wp8 doesn't work because callbacks not
initialized before call to open.