### PR TITLE
dealt with deprications in core iOS and cordova-android + Bug Fixes

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -15,6 +15,10 @@ import android.util.Log;
 
 import com.google.android.gcm.GCMBaseIntentService;
 
+import android.net.Uri; 
+import android.media.Ringtone; 
+import android.media.RingtoneManager;
+
 @SuppressLint("NewApi")
 public class GCMIntentService extends GCMBaseIntentService {
 
@@ -70,7 +74,11 @@ public class GCMIntentService extends GCMBaseIntentService {
 			}
 			else {
 				extras.putBoolean("foreground", false);
-
+                
+                Uri notificationUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+                Ringtone r = RingtoneManager.getRingtone(getApplicationContext(), notificationUri);
+                r.play();
+                
                 // Send a notification if there is a message
                 if (extras.getString("message") != null && extras.getString("message").length() != 0) {
                     createNotification(context, extras);

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -38,7 +38,8 @@
 }
 
 @property (nonatomic, copy) NSString *callbackId;
-@property (nonatomic, copy) NSString *notificationCallbackId;
+@property (retain, nonatomic) NSString *notificationCallbackId;
+//@property (nonatomic, copy) NSString *notificationCallbackId;
 @property (nonatomic, copy) NSString *callback;
 
 @property (nonatomic, strong) NSDictionary *notificationMessage;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -24,6 +24,7 @@
  */
 
 #import "PushPlugin.h"
+#define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 
 @implementation PushPlugin
 
@@ -158,8 +159,12 @@
         [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
 
         // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
-        NSUInteger rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
-
+        NSUInteger rntypes;
+        if (!SYSTEM_VERSION_LESS_THAN(@"8.0")) {
+            rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
+        }else{
+            rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+        }
         // Set the defaults to disabled unless we find otherwise...
         NSString *pushBadge = @"disabled";
         NSString *pushAlert = @"disabled";

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -203,25 +203,6 @@
 
     if (notificationMessage && self.callback)
     {
-        NSMutableString *jsonStr = [NSMutableString stringWithFormat:@"{\"method_name\":\"%@\",\"method_params\":",self.callback];
-
-        [self parseDictionary:notificationMessage intoJSON:jsonStr];
-        
-        if (isInline)
-        {
-            [jsonStr appendFormat:@"foreground:\"%d\"", 1];
-            isInline = NO;
-        }
-		else
-            [jsonStr appendFormat:@"foreground:\"%d\"", 0];
-
-        [jsonStr appendString:@"}"];
-
-        NSLog(@"Msg: %@", jsonStr);
-        
-        //NSString * jsCallBack = [NSString stringWithFormat:@"%@(%@);", self.callback, jsonStr];
-        //[self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
-        
         NSDictionary *jDict = @{
                 @"method_name":self.callback,
                 @"method_params":self.notificationMessage

--- a/www/PushNotification.js
+++ b/www/PushNotification.js
@@ -16,7 +16,23 @@ PushNotification.prototype.register = function(successCallback, errorCallback, o
         return
     }
 
-    cordova.exec(successCallback, errorCallback, "PushPlugin", "register", [options]);
+    cordova.exec(function(m){
+        console.log(m);
+        if(m.hasOwnProperty('method_name')){
+            var namespaces = m['method_name'].split(".");
+            var func = namespaces.pop();
+            var context = window;
+            for(var i = 0; i < namespaces.length; i++) {
+                context = context[namespaces[i]];
+            }
+            var args = undefined;
+            if(m.hasOwnProperty('method_params')){
+                args = m['method_params'];
+            }
+            return context[func].call(this,args);
+        }
+        else successCallback(m);
+    }, errorCallback, "PushPlugin", "register", [options]);
 };
 
 // Call this to unregister for push notifications


### PR DESCRIPTION
1. Handled deprecation of the Android webView.sendJavascript( ) . Refer  https://issues.apache.org/jira/browse/CB-6851 and http://mail-archives.apache.org/mod_mbox/cordova-commits/201406.mbox/%3Ceab8fbe6523947e88f8092f102568a95@git.apache.org%3E

2. Changed the way iOS calls the apn notification handler. Uses PluginResult instead of stringByEvaluatingJavaScriptFromString. The javascript passed in stringByEvaluatingJavaScriptFromString was not able to access stuff loaded by RequireJS

3. Handled deprecation of enabledRemoteNotificationTypes in iOS 8 and up