### PR TITLE
Fix deprecated proxy name for Windows Phone universal platform.

### DIFF
--- a/src/windows8/PushPluginProxy.js
+++ b/src/windows8/PushPluginProxy.js
@@ -15,4 +15,4 @@ module.exports = {
         }
     }
 };
-require("cordova/windows8/commandProxy").add("PushPlugin", module.exports);
+require("cordova/exec/proxy").add("PushPlugin", module.exports);


### PR DESCRIPTION
Fixes "windows commandProxy not found" error.