### PR TITLE
fix for iOS8 (from http://stackoverflow.com/a/26397526/1290746)

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -142,6 +142,8 @@
 }
 */
 
+#define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
 
     NSMutableDictionary *results = [NSMutableDictionary dictionary];
@@ -156,7 +158,13 @@
         [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
 
         // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
-        NSUInteger rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+        //NSUInteger rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+        NSUInteger rntypes;
+          if (!SYSTEM_VERSION_LESS_THAN(@"8.0")) {
+           rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
+        }else{
+           rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+        }
 
         // Set the defaults to disabled unless we find otherwise...
         NSString *pushBadge = @"disabled";


### PR DESCRIPTION
Hi,

This is my first github pull request.

I noticed I was getting the message that enabledRemoteNotificationTypes is not supported with iOS8 - I googled and found this stack overflow solution (http://stackoverflow.com/a/26397526/1290746) - I've implemented and tested the change, and this pull request is that change.