### PR TITLE
Avoid public exported activity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<activity android:name="com.plugin.gcm.PushHandlerActivity" android:exported="true"/>
+			<activity android:name="com.plugin.gcm.PushHandlerActivity"/>
 			<receiver android:name="com.plugin.gcm.CordovaGCMBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND" >
 				<intent-filter>
 					<action android:name="com.google.android.c2dm.intent.RECEIVE" />

--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -88,7 +88,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 		notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 		notificationIntent.putExtra("pushBundle", extras);
 
-		PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+		PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 		
 		int defaults = Notification.DEFAULT_ALL;
 


### PR DESCRIPTION
See:
https://code.google.com/p/android/issues/detail?id=61850
https://code.google.com/p/android/issues/detail?id=63236
http://stackoverflow.com/questions/21250364/notification-click-not-launch-the-given-activity-on-nexus-phones