### PR TITLE
Fixed iOS Push Notfication Service

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -215,12 +215,19 @@
 
         [jsonStr appendString:@"}"];
 
+        [jsonStr appendString:@"}"];
+ 
+ 
+ 
         NSLog(@"Msg: %@", jsonStr);
+		
+		NSLog(@"selfcallback: %@", self.callback);
+		
+		NSString *javascriptString = [NSString stringWithFormat:@"notificationReceived('%@')", currentState];
 
-        NSString * jsCallBack = [NSString stringWithFormat:@"%@(%@);", self.callback, jsonStr];
-        [self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
-
-        self.notificationMessage = nil;
+		[self.webView stringByEvaluatingJavaScriptFromString:javascriptString];
+ 
+		self.notificationMessage = nil;
     }
 }
 


### PR DESCRIPTION
When the apple push notification service is tested, the push notification successfully received when the app is running in the background but when the app is in the foreground the push notification event cannot be triggered, This issue has been fixed and tested.
